### PR TITLE
fix performance bug

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -235,7 +235,8 @@ class Memory(object):
     def return_random(self, size, index):
         if isinstance(index, torch.Tensor):
             index = index.tolist()
-        allowed = [x for x in range(2000) if x not in index]
+        #allowed = [x for x in range(2000) if x not in index]
+        allowed = [x for x in range(index[0])] + [x for x in range(index[0] + 1, 2000)]
         index = random.sample(allowed, size)
         return self.memory[index,:]
     def return_representations(self, index):


### PR DESCRIPTION
Dear @akwasigroch ,

I really appreciate the work you did writing this implementation of PIRL, and found it very useful.  I wanted to let you know about a tiny issue that actually slows the code down very significantly (generating random numbers).  This is especially important for larger data sets with >> 2k samples.

The way you had generate the 'allowed' list was an unexpected bottleneck that I found after a good amount of digging and trying to figure out why the NCE computations were taking so long.  It turned out that a subtle algorithmic change in generating the numbers, whereby you don't use an if statement in the list-comprehension, saves a lot of computation speed that is only compounded when running over many batches and epochs.

Anyways, please feel free to review yourself, and thanks again for this great implementation.

Alexander